### PR TITLE
Revert some PRs for using not 'data-table' but 'simple-table' for smartphone

### DIFF
--- a/src/components/parts/TableOfPostedIllustrations.vue
+++ b/src/components/parts/TableOfPostedIllustrations.vue
@@ -24,12 +24,6 @@
 
         <br />
 
-        <!-- <div> -->
-        <!-- <v-btn depressed color="primary" class="mr-2">応募状況一覧</v-btn> -->
-        <!-- <v-btn depressed color="primary">満了キャラ一覧</v-btn> -->
-        <!-- </div> -->
-        <!-- <br /> -->
-
         <div v-if="showLoadingAnime">
           <v-layout justify-center>
             <img src="../../assets/loading_spinner_anime.gif" />
@@ -52,41 +46,45 @@
           <p class="title text--primary font-weight-bold">
             キャラ別応募数
           </p>
+          <v-simple-table>
+            <template>
+              <thead>
+                <tr>
+                  <th class="text-left subtitle-1 font-weight-bold">
+                    キャラ名
+                  </th>
+                  <th class="text-left subtitle-1 font-weight-bold">応募数</th>
+                </tr>
+              </thead>
 
-          <v-row>
-            <v-col cols="12" sm="12" class="d-flex align-end flex-column">
-              <v-text-field
-                v-model="search"
-                append-icon="mdi-magnify"
-                label="キャラ名検索"
-                single-line
-                hide-details
-              ></v-text-field>
-            </v-col>
-          </v-row>
-          <v-data-table
-            :headers="headers"
-            :items="postedIllustrationsData()"
-            hide-default-footer
-            :items-per-page="500"
-            :search="search"
-          >
-            <template v-slot:item.numberOfPosted="{ item }">
-              <div v-if="isEntryClosed(item.numberOfPosted)">
-                <span
-                  :class="{
-                    'is-entry-closed': true,
-                    'font-weight-bold': true
-                  }"
+              <tbody>
+                <tr
+                  v-for="(numberOfVote,
+                  characterName) in sortedPostedIllustrationsStatus(
+                    this.postedIllustrationsStatus
+                  )"
+                  :key="characterName"
                 >
-                  {{ numberOfVoteWithNotion(item.numberOfPosted) }}
-                </span>
-              </div>
-              <div v-else>
-                {{ numberOfVoteWithNotion(item.numberOfPosted) }}
-              </div>
+                  <td>{{ characterName }}</td>
+                  <td>
+                    <div v-if="isEntryClosed(numberOfVote)">
+                      <span
+                        :class="{
+                          'is-entry-closed': true,
+                          'font-weight-bold': true
+                        }"
+                      >
+                        {{ numberOfVoteWithNotion(numberOfVote) }}
+                      </span>
+                    </div>
+                    <div v-else>
+                      {{ numberOfVoteWithNotion(numberOfVote) }}
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
             </template>
-          </v-data-table>
+          </v-simple-table>
         </div>
       </v-col>
     </v-row>
@@ -101,39 +99,10 @@ export default {
     return {
       postedIllustrationsStatus: null,
       currentStatusInfo: [],
-      showLoadingAnime: true,
-      search: "",
-      headers: [
-        {
-          text: "キャラ名",
-          align: "start",
-          sortable: false,
-          value: "charaName",
-          class: ["text-left", "subtitle-1", "font-weight-bold"]
-        },
-        {
-          text: "応募数",
-          value: "numberOfPosted",
-          class: ["text-left", "subtitle-1", "font-weight-bold"],
-          filterable: false
-        }
-      ]
+      showLoadingAnime: true
     };
   },
   methods: {
-    postedIllustrationsData: function() {
-      const arrayFromObject = Object.entries(
-        this.sortedPostedIllustrationsStatus(this.postedIllustrationsStatus)
-      );
-      const postedIllustrationsData = arrayFromObject.map(element => {
-        return {
-          charaName: element[0],
-          numberOfPosted: element[1]
-        };
-      });
-
-      return postedIllustrationsData;
-    },
     sumOfPostedIllustrations: function() {
       return Object.values(this.postedIllustrationsStatus).reduce(
         (sum, element) => sum + element,


### PR DESCRIPTION
Revert "Merge pull request #42 from true-runes/update_style_of_sum_of_posted_illustrations"

This reverts commit f1095a7cf54ea051c981b7ff425365f2b458f022, reversing
changes made to 231875cafd5ac92cbe78e241d9996fe1f37b51ba.

Revert "Add a sort function to posted illustrations page"

This reverts commit de8b6469de4cb7de9d31e24fdf9a7d1c3ed80062.

Fix some layouts