### PR TITLE
ci: 🎡 Renovate による vue の自動生成 PR では Vue 3 は除外する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
   },
   "packageRules": [
     {
+      "matchPackagNames": ["vue"],
+      "allowedVersions": "/^[2].*$/"
+    {
       "matchPackagePatterns": [
         ".*sass.*"
       ],


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#allowedversions