### PR TITLE
fix: 🐛 renovate.json が JSON フォーマットではないので修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     {
       "matchPackagNames": ["vue"],
       "allowedVersions": "/^[2].*$/"
+    },
     {
       "matchPackagePatterns": [
         ".*sass.*"


### PR DESCRIPTION
```bash
$ cat renovate.json | jq type
"object"
```